### PR TITLE
Added missing options to the application

### DIFF
--- a/ccx-main-window.cpp
+++ b/ccx-main-window.cpp
@@ -161,7 +161,7 @@ void CCXMainWindow::updateSourceOptions()
 					ui->leSourceTCPPass->setEnabled(false);
 					ui->leSourceTCPDesc->setEnabled(false);
 					sourceOptions = " -udp ";
-					sourceOptions += UDPhost.length() ? UDPhost : "";
+					sourceOptions += UDPhost.length() ? UDPhost + ":" : "";
 					sourceOptions += UDPport;
 				} else {
 					ui->leSourceTCPPort->setEnabled(true);

--- a/ccx-main-window.cpp
+++ b/ccx-main-window.cpp
@@ -150,13 +150,34 @@ void CCXMainWindow::updateSourceOptions()
 			break;
 		case 2: //network
 			{
-				QString host = ui->leSourceUDPHost->text(),
-						port = ui->leSourceUDPPort->text();
-				sourceOptions = " -udp ";
-				if (host.length()) {
-					sourceOptions += host + ":";
+				QString UDPhost = ui->leSourceUDPHost->text(),
+					UDPport = ui->leSourceUDPPort->text();
+				QString TCPport = ui->leSourceTCPPort->text(),
+					TCPpass = ui->leSourceTCPPass->text(),
+					TCPdesc = ui->leSourceTCPDesc->text();
+				sourceOptions = "";
+				if (UDPport.length()) {
+					ui->leSourceTCPPort->setEnabled(false);
+					ui->leSourceTCPPass->setEnabled(false);
+					ui->leSourceTCPDesc->setEnabled(false);
+					sourceOptions = " -udp ";
+					sourceOptions += UDPhost.length() ? UDPhost : "";
+					sourceOptions += UDPport;
+				} else {
+					ui->leSourceTCPPort->setEnabled(true);
+					ui->leSourceTCPPass->setEnabled(true);
+					ui->leSourceTCPDesc->setEnabled(true);
+					if(TCPport.length()) {
+						ui->leSourceUDPHost->setEnabled(false);
+						ui->leSourceUDPPort->setEnabled(false);
+						sourceOptions = " -tcp " + TCPport;
+						sourceOptions += TCPpass.length() ? " -tcppassword " + TCPpass : "";
+						sourceOptions += TCPdesc.length() ? " -tcpdesc " + TCPdesc : "";
+					} else {
+						ui->leSourceUDPHost->setEnabled(true);
+						ui->leSourceUDPPort->setEnabled(true);
+					}
 				}
-				sourceOptions += port;
 			}
 			break;
 	}
@@ -176,6 +197,24 @@ void CCXMainWindow::on_leSourceUDPHost_textChanged(const QString &arg1)
 }
 
 void CCXMainWindow::on_leSourceUDPPort_textChanged(const QString &arg1)
+{
+	Q_UNUSED(arg1);
+	this->updateSourceOptions();
+}
+
+void CCXMainWindow::on_leSourceTCPPort_textChanged(const QString &arg1)
+{
+	Q_UNUSED(arg1);
+	this->updateSourceOptions();
+}
+
+void CCXMainWindow::on_leSourceTCPPass_textChanged(const QString &arg1)
+{
+	Q_UNUSED(arg1);
+	this->updateSourceOptions();
+}
+
+void CCXMainWindow::on_leSourceTCPDesc_textChanged(const QString &arg1)
 {
 	Q_UNUSED(arg1);
 	this->updateSourceOptions();
@@ -254,8 +293,8 @@ void CCXMainWindow::on_ccextractor_message()
 			if (progress == 100) {
 				ui->btnViewLog->setEnabled(true);
 			}
-        }
-    }
+	   }
+	}
 }
 
 void CCXMainWindow::on_ccextractor_log()
@@ -264,7 +303,7 @@ void CCXMainWindow::on_ccextractor_log()
 	QString logLine;
 	while (extractionProcess->canReadLine()) {
 		logLine = extractionProcess->readLine();
-        out << logLine;
+	   out << logLine;
 	}
 }
 
@@ -287,8 +326,8 @@ void CCXMainWindow::on_menuBar_exit_clicked()
 
 void CCXMainWindow::on_menuBar_about_clicked()
 {
-    if (!aboutWindow) {
-        aboutWindow = new CCXAbout();
-    }
-    aboutWindow->show();
+	if (!aboutWindow) {
+	   aboutWindow = new CCXAbout();
+	}
+	aboutWindow->show();
 }

--- a/ccx-main-window.h
+++ b/ccx-main-window.h
@@ -24,6 +24,9 @@ private slots:
 	void on_twSource_currentChanged(int index);
 	void on_leSourceUDPHost_textChanged(const QString &arg1);
 	void on_leSourceUDPPort_textChanged(const QString &arg1);
+	void on_leSourceTCPPort_textChanged(const QString &arg1);
+	void on_leSourceTCPPass_textChanged(const QString &arg1);
+	void on_leSourceTCPDesc_textChanged(const QString &arg1);
 	void on_treeViewFileSystem_clicked(const QModelIndex &index);
 	void on_btnFileAdd_clicked();
 	void on_btnFileRemove_clicked();
@@ -45,7 +48,7 @@ private:
 	Ui::CCXMainWindow *ui;
 
 	CCXOptions *optionsWindow;
-    CCXAbout *aboutWindow;
+	CCXAbout *aboutWindow;
 
 	QString cmdline; //Result cmd line
 	QString options; //Options set in CCXOptions Window

--- a/ccx-main-window.ui
+++ b/ccx-main-window.ui
@@ -4,16 +4,16 @@
  <widget class="QMainWindow" name="CCXMainWindow">
   <property name="geometry">
    <rect>
-	<x>0</x>
-	<y>0</y>
-	<width>847</width>
-	<height>424</height>
+    <x>0</x>
+    <y>0</y>
+    <width>847</width>
+    <height>424</height>
    </rect>
   </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-	<horstretch>0</horstretch>
-	<verstretch>0</verstretch>
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
    </sizepolicy>
   </property>
   <property name="windowTitle">
@@ -21,7 +21,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="ccx-gui-res.qrc">
-	<normaloff>:/cc.png</normaloff>:/cc.png</iconset>
+    <normaloff>:/cc.png</normaloff>:/cc.png</iconset>
   </property>
   <property name="styleSheet">
    <string notr="true">QGroupBox { 
@@ -40,406 +40,461 @@ QGroupBox::title {
   </property>
   <widget class="QWidget" name="centralWidget">
    <property name="sizePolicy">
-	<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-	 <horstretch>0</horstretch>
-	 <verstretch>0</verstretch>
-	</sizepolicy>
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
    </property>
    <widget class="QGroupBox" name="gbSource">
-	<property name="geometry">
-	 <rect>
-	  <x>10</x>
-	  <y>0</y>
-	  <width>371</width>
-	  <height>351</height>
-	 </rect>
-	</property>
-	<property name="autoFillBackground">
-	 <bool>false</bool>
-	</property>
-	<property name="styleSheet">
-	 <string notr="true"/>
-	</property>
-	<property name="title">
-	 <string>Source</string>
-	</property>
-	<property name="flat">
-	 <bool>false</bool>
-	</property>
-	<widget class="QTabWidget" name="twSource">
-	 <property name="geometry">
-	  <rect>
-	   <x>10</x>
-	   <y>20</y>
-	   <width>351</width>
-	   <height>321</height>
-	  </rect>
-	 </property>
-	 <property name="currentIndex">
-	  <number>1</number>
-	 </property>
-	 <widget class="QWidget" name="tabFiles">
-	  <attribute name="title">
-	   <string>Files</string>
-	  </attribute>
-	  <widget class="QListWidget" name="lwFiles">
-	   <property name="geometry">
-		<rect>
-		 <x>-5</x>
-		 <y>0</y>
-		 <width>351</width>
-		 <height>251</height>
-		</rect>
-	   </property>
-	   <property name="horizontalScrollBarPolicy">
-		<enum>Qt::ScrollBarAlwaysOn</enum>
-	   </property>
-	  </widget>
-	  <widget class="QPushButton" name="btnFileRemove">
-	   <property name="geometry">
-		<rect>
-		 <x>200</x>
-		 <y>260</y>
-		 <width>71</width>
-		 <height>27</height>
-		</rect>
-	   </property>
-	   <property name="text">
-		<string>Remove</string>
-	   </property>
-	  </widget>
-	  <widget class="QPushButton" name="btnFileAdd">
-	   <property name="geometry">
-		<rect>
-		 <x>280</x>
-		 <y>260</y>
-		 <width>61</width>
-		 <height>27</height>
-		</rect>
-	   </property>
-	   <property name="text">
-		<string>Add...</string>
-	   </property>
-	  </widget>
-	 </widget>
-	 <widget class="QWidget" name="tabFileSystem">
-	  <attribute name="title">
-	   <string>Filesystem</string>
-	  </attribute>
-	  <widget class="QTreeView" name="treeViewFileSystem">
-	   <property name="geometry">
-		<rect>
-		 <x>0</x>
-		 <y>0</y>
-		 <width>351</width>
-		 <height>291</height>
-		</rect>
-	   </property>
-	   <property name="selectionMode">
-		<enum>QAbstractItemView::ExtendedSelection</enum>
-	   </property>
-	   <property name="selectionBehavior">
-		<enum>QAbstractItemView::SelectItems</enum>
-	   </property>
-	  </widget>
-	 </widget>
-	 <widget class="QWidget" name="tabNetwork">
-	  <attribute name="title">
-	   <string>Network</string>
-	  </attribute>
-	  <widget class="QGroupBox" name="gbUDP">
-	   <property name="geometry">
-		<rect>
-		 <x>10</x>
-		 <y>10</y>
-		 <width>331</width>
-		 <height>81</height>
-		</rect>
-	   </property>
-	   <property name="title">
-		<string>UDP</string>
-	   </property>
-	   <widget class="QWidget" name="formLayoutWidget_2">
-		<property name="geometry">
-		 <rect>
-		  <x>10</x>
-		  <y>20</y>
-		  <width>311</width>
-		  <height>61</height>
-		 </rect>
-		</property>
-		<layout class="QFormLayout" name="formLayout_2">
-		 <item row="0" column="0">
-		  <widget class="QLabel" name="labelSourceUDPHost">
-		   <property name="text">
-			<string>Host:</string>
-		   </property>
-		  </widget>
-		 </item>
-		 <item row="1" column="0">
-		  <widget class="QLabel" name="labelSourceUDPPort">
-		   <property name="text">
-			<string>Port:</string>
-		   </property>
-		  </widget>
-		 </item>
-		 <item row="0" column="1">
-		  <widget class="QLineEdit" name="leSourceUDPHost"/>
-		 </item>
-		 <item row="1" column="1">
-		  <widget class="QLineEdit" name="leSourceUDPPort"/>
-		 </item>
-		</layout>
-	   </widget>
-	  </widget>
-	 </widget>
-	</widget>
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>0</y>
+      <width>371</width>
+      <height>351</height>
+     </rect>
+    </property>
+    <property name="autoFillBackground">
+     <bool>false</bool>
+    </property>
+    <property name="styleSheet">
+     <string notr="true"/>
+    </property>
+    <property name="title">
+     <string>Source</string>
+    </property>
+    <property name="flat">
+     <bool>false</bool>
+    </property>
+    <widget class="QTabWidget" name="twSource">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>351</width>
+       <height>321</height>
+      </rect>
+     </property>
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
+     <widget class="QWidget" name="tabFiles">
+      <attribute name="title">
+       <string>Files</string>
+      </attribute>
+      <widget class="QListWidget" name="lwFiles">
+       <property name="geometry">
+        <rect>
+         <x>-5</x>
+         <y>0</y>
+         <width>351</width>
+         <height>251</height>
+        </rect>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOn</enum>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="btnFileRemove">
+       <property name="geometry">
+        <rect>
+         <x>200</x>
+         <y>260</y>
+         <width>71</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Remove</string>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="btnFileAdd">
+       <property name="geometry">
+        <rect>
+         <x>280</x>
+         <y>260</y>
+         <width>61</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Add...</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="tabFileSystem">
+      <attribute name="title">
+       <string>Filesystem</string>
+      </attribute>
+      <widget class="QTreeView" name="treeViewFileSystem">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>351</width>
+         <height>291</height>
+        </rect>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectItems</enum>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="tabNetwork">
+      <attribute name="title">
+       <string>Network</string>
+      </attribute>
+      <widget class="QGroupBox" name="gbUDP">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>331</width>
+         <height>81</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>UDP</string>
+       </property>
+       <widget class="QWidget" name="formLayoutWidget_2">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>20</y>
+          <width>311</width>
+          <height>61</height>
+         </rect>
+        </property>
+        <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelSourceUDPHost">
+           <property name="text">
+            <string>Host:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="labelSourceUDPPort">
+           <property name="text">
+            <string>Port:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="leSourceUDPHost"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="leSourceUDPPort"/>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+      <widget class="QGroupBox" name="gbTCP">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>100</y>
+         <width>331</width>
+         <height>111</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>TCP</string>
+       </property>
+       <widget class="QWidget" name="formLayoutWidget_3">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>20</y>
+          <width>311</width>
+          <height>81</height>
+         </rect>
+        </property>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelSourceTCP">
+           <property name="text">
+            <string>Port:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="leSourceTCPPort"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="labelSourceTCPPass">
+           <property name="text">
+            <string>Password:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="leSourceTCPPass"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="labelSourceTCPPort">
+           <property name="text">
+            <string>Description:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="leSourceTCPDesc"/>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </widget>
+    </widget>
    </widget>
    <widget class="QGroupBox" name="gbSummary">
-	<property name="geometry">
-	 <rect>
-	  <x>390</x>
-	  <y>0</y>
-	  <width>451</width>
-	  <height>211</height>
-	 </rect>
-	</property>
-	<property name="title">
-	 <string>Summary</string>
-	</property>
-	<widget class="QWidget" name="formLayoutWidget">
-	 <property name="geometry">
-	  <rect>
-	   <x>10</x>
-	   <y>20</y>
-	   <width>431</width>
-	   <height>71</height>
-	  </rect>
-	 </property>
-	 <layout class="QFormLayout" name="formLayout">
-	  <property name="horizontalSpacing">
-	   <number>6</number>
-	  </property>
-	  <property name="verticalSpacing">
-	   <number>12</number>
-	  </property>
-	  <property name="topMargin">
-	   <number>0</number>
-	  </property>
-	  <item row="0" column="0">
-	   <widget class="QLabel" name="labelInput">
-		<property name="text">
-		 <string>Input type:</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item row="0" column="1">
-	   <widget class="QLabel" name="labelInputValue">
-		<property name="text">
-		 <string>input</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item row="1" column="0">
-	   <widget class="QLabel" name="labelOutput">
-		<property name="text">
-		 <string>Output type:</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item row="1" column="1">
-	   <widget class="QLabel" name="labelOutputValue">
-		<property name="text">
-		 <string>output</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item row="2" column="0">
-	   <widget class="QLabel" name="labelOutputPath">
-		<property name="text">
-		 <string>Output path:</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item row="2" column="1">
-	   <widget class="QLabel" name="labelOutputPathValue">
-		<property name="text">
-		 <string>filename</string>
-		</property>
-	   </widget>
-	  </item>
-	 </layout>
-	</widget>
-	<widget class="QLabel" name="labelCmd">
-	 <property name="geometry">
-	  <rect>
-	   <x>10</x>
-	   <y>100</y>
-	   <width>101</width>
-	   <height>15</height>
-	  </rect>
-	 </property>
-	 <property name="text">
-	  <string>Command Line:</string>
-	 </property>
-	</widget>
-	<widget class="QPlainTextEdit" name="pteCommandLine">
-	 <property name="enabled">
-	  <bool>false</bool>
-	 </property>
-	 <property name="geometry">
-	  <rect>
-	   <x>10</x>
-	   <y>120</y>
-	   <width>431</width>
-	   <height>81</height>
-	  </rect>
-	 </property>
-	 <property name="plainText">
-	  <string/>
-	 </property>
-	</widget>
+    <property name="geometry">
+     <rect>
+      <x>390</x>
+      <y>0</y>
+      <width>451</width>
+      <height>211</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Summary</string>
+    </property>
+    <widget class="QWidget" name="formLayoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>431</width>
+       <height>71</height>
+      </rect>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="horizontalSpacing">
+       <number>6</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>12</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelInput">
+        <property name="text">
+         <string>Input type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelInputValue">
+        <property name="text">
+         <string>input</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelOutput">
+        <property name="text">
+         <string>Output type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="labelOutputValue">
+        <property name="text">
+         <string>output</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelOutputPath">
+        <property name="text">
+         <string>Output path:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="labelOutputPathValue">
+        <property name="text">
+         <string>filename</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QLabel" name="labelCmd">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>100</y>
+       <width>101</width>
+       <height>15</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Command Line:</string>
+     </property>
+    </widget>
+    <widget class="QPlainTextEdit" name="pteCommandLine">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>120</y>
+       <width>431</width>
+       <height>81</height>
+      </rect>
+     </property>
+     <property name="plainText">
+      <string/>
+     </property>
+    </widget>
    </widget>
    <widget class="QProgressBar" name="pbExtraction">
-	<property name="geometry">
-	 <rect>
-	  <x>190</x>
-	  <y>360</y>
-	  <width>551</width>
-	  <height>31</height>
-	 </rect>
-	</property>
-	<property name="value">
-	 <number>0</number>
-	</property>
+    <property name="geometry">
+     <rect>
+      <x>190</x>
+      <y>360</y>
+      <width>551</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="value">
+     <number>0</number>
+    </property>
    </widget>
    <widget class="QPushButton" name="btnViewLog">
-	<property name="enabled">
-	 <bool>false</bool>
-	</property>
-	<property name="geometry">
-	 <rect>
-	  <x>750</x>
-	  <y>360</y>
-	  <width>91</width>
-	  <height>27</height>
-	 </rect>
-	</property>
-	<property name="text">
-	 <string>Show Log</string>
-	</property>
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>750</x>
+      <y>360</y>
+      <width>91</width>
+      <height>27</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Show Log</string>
+    </property>
    </widget>
    <widget class="QGroupBox" name="gbExecution">
-	<property name="geometry">
-	 <rect>
-	  <x>390</x>
-	  <y>220</y>
-	  <width>451</width>
-	  <height>131</height>
-	 </rect>
-	</property>
-	<property name="title">
-	 <string>Quick Options</string>
-	</property>
-	<widget class="QWidget" name="verticalLayoutWidget">
-	 <property name="geometry">
-	  <rect>
-	   <x>10</x>
-	   <y>20</y>
-	   <width>431</width>
-	   <height>101</height>
-	  </rect>
-	 </property>
-	 <layout class="QVBoxLayout" name="verticalLayout">
-	  <item>
-	   <widget class="QLabel" name="labelAdditionalOptions">
-		<property name="text">
-		 <string>Additional Options:</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item>
-	   <widget class="QLineEdit" name="leAdditionalOptions"/>
-	  </item>
-	  <item>
-	   <widget class="QCheckBox" name="cbVerboseLog">
-		<property name="text">
-		 <string>Verbose log</string>
-		</property>
-	   </widget>
-	  </item>
-	  <item>
-	   <widget class="QCheckBox" name="cbOpenOutputAfter">
-		<property name="enabled">
-		 <bool>false</bool>
-		</property>
-		<property name="text">
-		 <string>Open output file after extraction</string>
-		</property>
-	   </widget>
-	  </item>
-	 </layout>
-	</widget>
+    <property name="geometry">
+     <rect>
+      <x>390</x>
+      <y>220</y>
+      <width>451</width>
+      <height>131</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Quick Options</string>
+    </property>
+    <widget class="QWidget" name="verticalLayoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>431</width>
+       <height>101</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="labelAdditionalOptions">
+        <property name="text">
+         <string>Additional Options:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="leAdditionalOptions"/>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cbVerboseLog">
+        <property name="text">
+         <string>Verbose log</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cbOpenOutputAfter">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Open output file after extraction</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </widget>
    <widget class="QPushButton" name="btnExtract">
-	<property name="geometry">
-	 <rect>
-	  <x>10</x>
-	  <y>360</y>
-	  <width>81</width>
-	  <height>27</height>
-	 </rect>
-	</property>
-	<property name="text">
-	 <string>Extract</string>
-	</property>
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>360</y>
+      <width>81</width>
+      <height>27</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Extract</string>
+    </property>
    </widget>
    <widget class="QPushButton" name="btnOptions">
-	<property name="geometry">
-	 <rect>
-	  <x>100</x>
-	  <y>360</y>
-	  <width>81</width>
-	  <height>27</height>
-	 </rect>
-	</property>
-	<property name="text">
-	 <string>Options...</string>
-	</property>
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>360</y>
+      <width>81</width>
+      <height>27</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Options...</string>
+    </property>
    </widget>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">
-	<rect>
-	 <x>0</x>
-	 <y>0</y>
-	 <width>847</width>
-	 <height>25</height>
-	</rect>
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>847</width>
+     <height>21</height>
+    </rect>
    </property>
    <widget class="QMenu" name="menuFile">
-	<property name="title">
-	 <string>File</string>
-	</property>
-	<addaction name="actionExit"/>
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
-	<property name="title">
-	 <string>Help</string>
-	</property>
-	<addaction name="actionAbout"/>
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionAbout"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuHelp"/>
   </widget>
   <action name="actionExit">
    <property name="text">
-	<string>Exit</string>
+    <string>Exit</string>
    </property>
   </action>
   <action name="actionAbout">
    <property name="text">
-	<string>About...</string>
+    <string>About...</string>
    </property>
   </action>
  </widget>

--- a/ccx-options.cpp
+++ b/ccx-options.cpp
@@ -35,6 +35,10 @@ CCXOptions::CCXOptions(QWidget *parent) :
 	ui->cbOutputType->addItem("bin (CCExtractor binary)", "-out=bin");
 	ui->cbOutputType->addItem("raw (McPoodle Broadcast)", "-out=raw");
 	ui->cbOutputType->addItem("dvdraw (McPoodle DVD)", "-out=dvdraw");
+	ui->cbOutputType->addItem("ass (SubStation Alpha)", "-out=ass");
+	ui->cbOutputType->addItem("ssa (SubStation Alpha)", "-out=ssa");
+	ui->cbOutputType->addItem("webvtt (WebVTT format)", "-out=webvtt");
+	ui->cbOutputType->addItem("report (stdout caption info)", "-out=report");
 	ui->cbOutputType->addItem("stdout (Write to stdout)", "-stdout");
 
 	this->setWindowTitle("CCExtractor options");
@@ -82,6 +86,7 @@ QString CCXOptions::getCommandLineOptionsString()
 	options += this->getOptionsInputString();
 	options += this->getOptionsDebugString();
 	options += this->getOptionsOutputString();
+	options += this->getOptionsDecoderString();
 	options += this->getOptionsCreditsString();
 	options += this->getOptionsHardsubxString();
 
@@ -92,14 +97,14 @@ QString CCXOptions::getOptionsInputString()
 {
 	QString inputOptions;
 
-    if (ui->cbInputType->currentData().toString().length()) {
-        inputOptions += " " + ui->cbInputType->currentData().toString();
-    }
-    if (ui->cbSplitType->currentData().toString().length()) {
-        inputOptions += " " + ui->cbSplitType->currentData().toString();
-    }
+	if (ui->cbInputType->currentData().toString().length()) {
+		inputOptions += " " + ui->cbInputType->currentData().toString();
+	}
+	if (ui->cbSplitType->currentData().toString().length()) {
+		inputOptions += " " + ui->cbSplitType->currentData().toString();
+	}
 
-    if (ui->cbLiveStream->isChecked()) {
+	if (ui->cbLiveStream->isChecked()) {
 		inputOptions += " -s";
 		if (ui->sbLiveStreamWait->value()) {
 			inputOptions += " " + QString::number(ui->sbLiveStreamWait->value());
@@ -150,6 +155,14 @@ QString CCXOptions::getOptionsInputString()
 	inputOptions += ui->rbTeletextForce->isChecked() ? " -teletext" : "";
 	inputOptions += ui->rbTeletextDisable->isChecked() ? " -noteletext" : "";
 
+	inputOptions += ui->rbCodecDVB->isChecked() ? " -codec dvbsub " : "";
+	inputOptions += ui->rbNocodecDVB->isChecked() ? " -nocodec dvbsub " : "";
+	inputOptions += ui->rbCodecTeletext->isChecked() ? " -codec teletext " : "";
+	inputOptions += ui->rbNocodecTeletext->isChecked() ? " -nocodec teletext " : "";
+
+	inputOptions += ui->cbWTVMPEG->isChecked() ? " -wtvmpeg2" : "";
+	inputOptions += ui->cbNoSCTE20->isChecked() ? " --noscte20" : "";
+
 	if (ui->cbTeletextPage->isChecked()) {
 		inputOptions += " -tpage " + QString::number(ui->sbTeletextPage->value());
 	}
@@ -174,6 +187,7 @@ QString CCXOptions::getOptionsDebugString()
 	debugOptions += ui->cbDebugPMT->isChecked() ? " -parsePMT" : "";
 	debugOptions += ui->cbDebugInvestigate->isChecked() ? " -investigate_packets" : "";
 	debugOptions += ui->cbDebugTeletext->isChecked() ? " -tverbose" : "";
+	debugOptions += ui->cbDebugDumpdef->isChecked() ? "-dumpdef" : "";
 
 	if (ui->cbDebugESFile->isChecked()) {
 		debugOptions += " -cf " + ui->leDebugESFile->text();
@@ -194,6 +208,7 @@ QString CCXOptions::getOptionsOutputString()
 		outputOptions += " -delay " + QString::number(ui->sbSubDelay->value());
 	}
 	outputOptions += ui->rbEncodingLatin1->isChecked() ? " -latin1" : "";
+	outputOptions += ui->rbEncodingUnicode->isChecked() ? " -unicode" : "";
 	outputOptions += ui->rbOutputNewLineLF->isChecked() ? " -lf" : "";
 	outputOptions += ui->cbOutputSentenceCap->isChecked() ? " -sc" : "";
 
@@ -219,6 +234,29 @@ QString CCXOptions::getOptionsOutputString()
 	outputOptions += ui->rbOutputTranscriptTimeDate->isChecked() ? " -datets" : "";
 	outputOptions += ui->rbOutputTranscriptTimeSSMS->isChecked() ? " -sects" : "";
 
+	//Output (2)
+
+	outputOptions += ui->rbAppendBOM->isChecked() ? " -bom" : "";
+	outputOptions += ui->rbNoBOM->isChecked() ? " -nobom" : "";
+	outputOptions += ui->cbNoHTMLEscape->isChecked() ? " --nohtmlescape" : "";
+	outputOptions += ui->cbXMLTV->isChecked() ? " -xmltv" : "";
+	outputOptions += ui->cbSEM->isChecked() ? " -sem" : "";
+
+	if (ui->cbOutputInterval->isChecked()){
+		outputOptions += " -outinterval " + ui->leOutputInterval->text();
+	}
+
+	if (ui->gbOutputTranscriptCustom->isEnabled()){
+		outputOptions += " -customtxt ";
+		outputOptions += ui->cbTranscriptStart->isChecked() ? "1" : "0";
+		outputOptions += ui->cbTranscriptEnd->isChecked() ? "1" : "0";
+		outputOptions += ui->cbTranscriptMode->isChecked() ? "1" : "0";
+		outputOptions += ui->cbTranscriptChannel->isChecked() ? "1" : "0";
+		outputOptions += ui->cbTranscriptRelative->isChecked() ? "1" : "0";
+		outputOptions += ui->cbTranscriptXDS->isChecked() ? "1" : "0";
+		outputOptions += ui->cbTranscriptColors->isChecked() ? "1" : "0";
+	}
+
 	return outputOptions;
 }
 
@@ -231,6 +269,8 @@ QString CCXOptions::getOptionsDecoderString()
 	if (ui->cbDecoderBufferSize->isChecked()) {
 		decoderOptions += " -bs " + ui->leDecoderBufferSize->text();
 	}
+	decoderOptions += ui->cbKOC->isChecked() ? " -koc" : "";
+	decoderOptions += ui->cbForceFlush->isChecked() ? " -ff": "";
 
 	decoderOptions += ui->cbDecoderRollUpDirect->isChecked() ? " -dru" : "";
 	decoderOptions += ui->cbDecoderRollUpLineOnce->isChecked() ? " -noru" : "";
@@ -253,6 +293,8 @@ QString CCXOptions::getOptionsDecoderString()
 	}
 
 	decoderOptions += ui->cbDecoderChannel2->isChecked() ? " -cc2" : "";
+
+	decoderOptions += ui->cbCEA708EnableServices->isChecked() ? " -svc " + ui->leCEA708Services->text() : "";
 
 	return decoderOptions;
 }
@@ -296,39 +338,39 @@ QString CCXOptions::getOptionsHardsubxString()
 {
 	QString hardsubxOptions;
 
-    if (ui->cbHardsubx->isChecked()) {
+	if (ui->cbHardsubx->isChecked()) {
 		hardsubxOptions += " -hardsubx";
 
 		//Subtitle color
-        if (ui->rbSubColorWhite->isChecked()) {
+		if (ui->rbSubColorWhite->isChecked()) {
 			hardsubxOptions += " -subcolor white";
-        } else if (ui->rbSubColorYellow->isChecked()) {
+		} else if (ui->rbSubColorYellow->isChecked()) {
 			hardsubxOptions += " -subcolor yellow";
-        } else if (ui->rbSubColorGreen->isChecked()) {
+		} else if (ui->rbSubColorGreen->isChecked()) {
 			hardsubxOptions += " -subcolor green";
-        } else if (ui->rbSubColorCyan->isChecked()) {
+		} else if (ui->rbSubColorCyan->isChecked()) {
 			hardsubxOptions += " -subcolor cyan";
-        } else if (ui->rbSubColorBlue->isChecked()) {
+		} else if (ui->rbSubColorBlue->isChecked()) {
 			hardsubxOptions += " -subcolor blue";
-        } else if (ui->rbSubColorMagenta->isChecked()) {
+		} else if (ui->rbSubColorMagenta->isChecked()) {
 			hardsubxOptions += " -subcolor magenta";
-        } else if (ui->rbSubColorRed->isChecked()) {
+		} else if (ui->rbSubColorRed->isChecked()) {
 			hardsubxOptions += " -subcolor red";
-        } else if (ui->rbSubColorCustom->isChecked()) {
+		} else if (ui->rbSubColorCustom->isChecked()) {
 			hardsubxOptions += " -subcolor " + ui->leSubColorCustom->text();
 		}
 
 		//OCR Mode
-        if (ui->rbOcrModeFrame->isChecked()) {
+		if (ui->rbOcrModeFrame->isChecked()) {
 			hardsubxOptions += " -ocr_mode frame";
-        } else if (ui->rbOcrModeWord->isChecked()) {
+		} else if (ui->rbOcrModeWord->isChecked()) {
 			hardsubxOptions += " -ocr_mode word";
-        } else if (ui->rbOcrModeLetter->isChecked()) {
+		} else if (ui->rbOcrModeLetter->isChecked()) {
 			hardsubxOptions += " -ocr_mode letter";
 		}
 
 		//Detect Italics
-        if (ui->cbEnableItalicDetection->isChecked()) {
+		if (ui->cbEnableItalicDetection->isChecked()) {
 			hardsubxOptions += " -detect_italics";
 		}
 
@@ -336,13 +378,13 @@ QString CCXOptions::getOptionsHardsubxString()
 		hardsubxOptions += " -min_sub_duration " + ui->leMinSubDuration->text();
 
 		//Confidence Threshold
-        if (ui->hsConfThresh->value() > 0.0 && ui->hsConfThresh->value() <= 100.0) {
+		if (ui->hsConfThresh->value() > 0.0 && ui->hsConfThresh->value() <= 100.0) {
 			hardsubxOptions += " -conf_thresh " + QString::number(ui->hsConfThresh->value());
 		}
 
 		//Luminance Threshold
-        if (ui->hsLumThresh->value() > 0.0 && ui->hsLumThresh->value() <= 100.0) {
-            if (ui->rbSubColorWhite->isChecked()) {
+		if (ui->hsLumThresh->value() > 0.0 && ui->hsLumThresh->value() <= 100.0) {
+			if (ui->rbSubColorWhite->isChecked()) {
 				hardsubxOptions += " -lum_thresh " + QString::number(ui->hsLumThresh->value());
 			}
 		}
@@ -515,8 +557,10 @@ void CCXOptions::on_cbOutputType_currentIndexChanged(int index)
 	if (ui->cbOutputType->currentData().toString() == "-out=txt" ||
 			ui->cbOutputType->currentData().toString() == "-out=ttxt") {
 		ui->gbOutputTranscript->setEnabled(true);
+		ui->gbOutputTranscript2->setEnabled(true);
 	} else {
 		ui->gbOutputTranscript->setEnabled(false);
+		ui->gbOutputTranscript2->setEnabled(false);
 	}
 
 	if (ui->cbOutputType->currentData().toString() == "" || //srt
@@ -572,4 +616,14 @@ void CCXOptions::on_cbDecoderRollUpLimit_toggled(bool checked)
 void CCXOptions::on_cbCEA708EnableServices_toggled(bool checked)
 {
 	ui->leCEA708Services->setEnabled(checked);
+}
+
+void CCXOptions::on_cbOutputInterval_toggled(bool checked)
+{
+	ui->leOutputInterval->setEnabled(checked);
+}
+
+void CCXOptions::on_cbOutputTranscriptCustom_toggled(bool checked)
+{
+	ui->gbOutputTranscriptCustom->setEnabled(!checked);
 }

--- a/ccx-options.h
+++ b/ccx-options.h
@@ -36,6 +36,10 @@ private slots:
 	void on_cbMultiprogram_toggled(bool checked);
 	void on_rbMultiprogramNumber_toggled(bool checked);
 	void on_btnOutputPath_clicked();
+	void on_cbTranslate_toggled(bool checked);
+	void on_cbMKVLang_toggled(bool checked);
+	void on_cbOCRName_toggled(bool checked);
+	void on_buttonOCRName_clicked();
 	void on_cbTeletextPage_toggled(bool checked);
 	void on_cbEnableStartCredits_toggled(bool checked);
 	void on_cbEnableEndCredits_toggled(bool checked);
@@ -46,6 +50,15 @@ private slots:
 	void on_btnOutputCapFile_clicked();
 	void on_cbOutputCapFile_toggled(bool checked);
 	void on_cbOutputDefaultColor_toggled(bool checked);
+	void on_cbInputType_currentIndexChanged(int index);
+	void on_cbNoLeven_toggled(bool checked);
+	void on_cbMinNum_toggled(bool checked);
+	void on_cbMaxPct_toggled(bool checked);
+	void on_cbEnableSharing_toggled(bool checked);
+	void on_cbOutputFont_toggled(bool checked);
+	void on_btnOutputFont_clicked();
+	void on_cbXMLTV_toggled(bool checked);
+	void on_cbXMLTVInterval_toggled(bool checked);
 	void on_cbOutputType_currentIndexChanged(int index);
 	void on_cbOutputTrim_toggled(bool checked);
 	void on_cbOutputInterval_toggled(bool checked);

--- a/ccx-options.h
+++ b/ccx-options.h
@@ -48,6 +48,8 @@ private slots:
 	void on_cbOutputDefaultColor_toggled(bool checked);
 	void on_cbOutputType_currentIndexChanged(int index);
 	void on_cbOutputTrim_toggled(bool checked);
+	void on_cbOutputInterval_toggled(bool checked);
+	void on_cbOutputTranscriptCustom_toggled(bool checked);
 	void on_rbDecoderBufferDisable_toggled(bool checked);
 	void on_cbDecoderBufferSize_toggled(bool checked);
 	void on_btnDebugESFile_clicked();

--- a/ccx-options.ui
+++ b/ccx-options.ui
@@ -42,7 +42,7 @@ QGroupBox::title {
     </rect>
    </property>
    <property name="currentIndex">
-    <number>2</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="tabInput">
     <attribute name="title">
@@ -553,9 +553,9 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>10</y>
+       <y>140</y>
        <width>721</width>
-       <height>241</height>
+       <height>251</height>
       </rect>
      </property>
      <property name="title">
@@ -621,6 +621,20 @@ QGroupBox::title {
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="cbWTVMPEG">
+         <property name="text">
+          <string>Read captions from MPEG2 video stream over the WTV file</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbNoSCTE20">
+         <property name="text">
+          <string>Ignore SCTE-20 data</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
           <widget class="QCheckBox" name="cbScreenfuls">
@@ -663,6 +677,66 @@ QGroupBox::title {
           </spacer>
          </item>
         </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbInputCodec">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>0</y>
+       <width>721</width>
+       <height>131</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Codec</string>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget_6">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>631</width>
+        <height>101</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QRadioButton" name="radioButton">
+         <property name="text">
+          <string>None</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbCodecDVB">
+         <property name="text">
+          <string>Select dvb subtitle</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbNocodecDVB">
+         <property name="text">
+          <string>Ignore dvb subtitle</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbCodecTeletext">
+         <property name="text">
+          <string>Select teletext subtitle</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbNocodecTeletext">
+         <property name="text">
+          <string>Ignore teletext subtitle</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -1189,20 +1263,6 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="cbDebug608">
-        <property name="text">
-         <string>608 (Print debug traces from the EIA-608 decoder)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QCheckBox" name="cbDebugES">
-        <property name="text">
-         <string>ES (Print debug info about the analyzed elementary video stream)</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="cbDebugPTS">
         <property name="text">
@@ -1217,10 +1277,17 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="9" column="0">
-       <widget class="QCheckBox" name="cbDebugPAT">
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="cbDebugES">
         <property name="text">
-         <string>PAT (Print Program Association Table dump)</string>
+         <string>ES (Print debug info about the analyzed elementary video stream)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="cbDebug608">
+        <property name="text">
+         <string>608 (Print debug traces from the EIA-608 decoder)</string>
         </property>
        </widget>
       </item>
@@ -1238,10 +1305,24 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
+      <item row="9" column="0">
+       <widget class="QCheckBox" name="cbDebugPAT">
+        <property name="text">
+         <string>PAT (Print Program Association Table dump)</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="0">
        <widget class="QCheckBox" name="cbDebugXDS">
         <property name="text">
          <string>XDS (Enable XDS debug data (lots of it))</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QCheckBox" name="cbDebugTeletext">
+        <property name="text">
+         <string>Teletext decoder verbose mode</string>
         </property>
        </widget>
       </item>
@@ -1259,14 +1340,7 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="12" column="0">
-       <widget class="QCheckBox" name="cbDebugTeletext">
-        <property name="text">
-         <string>Teletext decoder verbose mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0">
+      <item row="14" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_13">
         <item>
          <widget class="QCheckBox" name="cbDebugESFile">
@@ -1293,6 +1367,13 @@ QGroupBox::title {
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="13" column="0">
+       <widget class="QCheckBox" name="cbDebugDumpdef">
+        <property name="text">
+         <string>Hex-dump defective TS packets</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -1443,13 +1524,26 @@ QGroupBox::title {
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>50</y>
+        <y>40</y>
         <width>107</width>
         <height>20</height>
        </rect>
       </property>
       <property name="text">
        <string>Latin &amp;1</string>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbEncodingUnicode">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Unicode</string>
       </property>
      </widget>
     </widget>
@@ -1743,6 +1837,214 @@ QGroupBox::title {
      </widget>
     </widget>
    </widget>
+   <widget class="QWidget" name="tabOutput2">
+    <attribute name="title">
+     <string>Output (2)</string>
+    </attribute>
+    <widget class="QGroupBox" name="gbOutputMisc">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>200</y>
+       <width>721</width>
+       <height>191</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Miscellaneous</string>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget_7">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>271</width>
+        <height>191</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QRadioButton" name="radioButton_2">
+         <property name="text">
+          <string>Use default byte order mark behavior</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbAppendBOM">
+         <property name="text">
+          <string>Append a byte order mark to output files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbNoBOM">
+         <property name="text">
+          <string>Don't append a byte order mark to output files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbNoHTMLEscape">
+         <property name="text">
+          <string>Don't convert HTML unsafe characters</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbXMLTV">
+         <property name="text">
+          <string>Produce an XMLTV file containing EPG data</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbSEM">
+         <property name="text">
+          <string>Create a .sem file for each output file that is open</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="cbOutputInterval">
+           <property name="text">
+            <string>Output interval (seconds)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="leOutputInterval">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>30</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbOutputTranscript2">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>0</y>
+       <width>721</width>
+       <height>191</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Transcript</string>
+     </property>
+     <widget class="QCheckBox" name="cbOutputTranscriptCustom">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>269</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Use default options</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QGroupBox" name="gbOutputTranscriptCustom">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>150</x>
+        <y>10</y>
+        <width>281</width>
+        <height>181</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Custom options</string>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+      <widget class="QWidget" name="verticalLayoutWidget_8">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>271</width>
+         <height>157</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_8">
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptStart">
+          <property name="text">
+           <string>Display start time</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptEnd">
+          <property name="text">
+           <string>Display end time</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptMode">
+          <property name="text">
+           <string>Display caption mode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptChannel">
+          <property name="text">
+           <string>Display caption channel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptRelative">
+          <property name="text">
+           <string>Use a timestamp relative to the sample</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptXDS">
+          <property name="text">
+           <string>Display XDS info</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbTranscriptColors">
+          <property name="text">
+           <string>Use colors</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </widget>
    <widget class="QWidget" name="tabDecoder">
     <attribute name="title">
      <string>Decoder</string>
@@ -1753,11 +2055,11 @@ QGroupBox::title {
        <x>520</x>
        <y>10</y>
        <width>211</width>
-       <height>141</height>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
-      <string>Input buffer</string>
+      <string>Buffers</string>
      </property>
      <widget class="QWidget" name="verticalLayoutWidget_4">
       <property name="geometry">
@@ -1765,7 +2067,7 @@ QGroupBox::title {
         <x>10</x>
         <y>20</y>
         <width>191</width>
-        <height>120</height>
+        <height>145</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -1795,6 +2097,13 @@ QGroupBox::title {
        </item>
        <item>
         <layout class="QFormLayout" name="formLayout_4">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="cbDecoderBufferSize">
+           <property name="text">
+            <string>Buffer size</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="1">
           <widget class="QLineEdit" name="leDecoderBufferSize">
            <property name="enabled">
@@ -1805,10 +2114,17 @@ QGroupBox::title {
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="cbDecoderBufferSize">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="cbKOC">
            <property name="text">
-            <string>Buffer size</string>
+            <string>Keep output close</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="cbForceFlush">
+           <property name="text">
+            <string>Force buffer flush</string>
            </property>
           </widget>
          </item>
@@ -1823,7 +2139,7 @@ QGroupBox::title {
        <x>240</x>
        <y>10</y>
        <width>271</width>
-       <height>141</height>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
@@ -1914,7 +2230,7 @@ QGroupBox::title {
        <x>10</x>
        <y>10</y>
        <width>221</width>
-       <height>141</height>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
@@ -1967,7 +2283,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>160</y>
+       <y>180</y>
        <width>721</width>
        <height>61</height>
       </rect>
@@ -2020,8 +2336,8 @@ QGroupBox::title {
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans';&quot;&gt;CCExtractor can _try_ to add a custom message (for credits for example) at the start and end of the file, looking for a window where there are no captions. If there is no such window, then no text will be added. The start window must be between the times given and must have enough time to display the message for at least the specified time.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans'; font-size:10pt;&quot;&gt;CCExtractor can _try_ to add a custom message (for credits for example) at the start and end of the file, looking for a window where there are no captions. If there is no such window, then no text will be added. The start window must be between the times given and must have enough time to display the message for at least the specified time.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
     <widget class="QGroupBox" name="gbCreditsStart">
@@ -2292,9 +2608,9 @@ p, li { white-space: pre-wrap; }
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans'; color:#ae2e1a;&quot;&gt;1. All connditions must be met, otherwise no text will be added.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans'; color:#ae2e1a;&quot;&gt;2. If you plan to distribute the output files non-comercially, please consider leaving a reference to CCExtractor&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans'; font-size:10pt; color:#ae2e1a;&quot;&gt;1. All connditions must be met, otherwise no text will be added.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans'; font-size:10pt; color:#ae2e1a;&quot;&gt;2. If you plan to distribute the output files non-comercially, please consider leaving a reference to CCExtractor&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </widget>

--- a/ccx-options.ui
+++ b/ccx-options.ui
@@ -36,13 +36,13 @@ QGroupBox::title {
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>10</y>
+     <y>0</y>
      <width>741</width>
      <height>431</height>
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>4</number>
    </property>
    <widget class="QWidget" name="tabInput">
     <attribute name="title">
@@ -255,9 +255,9 @@ QGroupBox::title {
     <widget class="QGroupBox" name="gbMythTV">
      <property name="geometry">
       <rect>
-       <x>430</x>
+       <x>420</x>
        <y>130</y>
-       <width>301</width>
+       <width>201</width>
        <height>111</height>
       </rect>
      </property>
@@ -312,7 +312,7 @@ QGroupBox::title {
       <rect>
        <x>100</x>
        <y>130</y>
-       <width>321</width>
+       <width>311</width>
        <height>111</height>
       </rect>
      </property>
@@ -324,7 +324,7 @@ QGroupBox::title {
        <rect>
         <x>10</x>
         <y>20</y>
-        <width>301</width>
+        <width>291</width>
         <height>92</height>
        </rect>
       </property>
@@ -349,6 +349,16 @@ QGroupBox::title {
          </property>
          <property name="checked">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="rbMultiprogram">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Process all suitable programs</string>
          </property>
         </widget>
        </item>
@@ -544,6 +554,48 @@ QGroupBox::title {
       </layout>
      </widget>
     </widget>
+    <widget class="QGroupBox" name="gbPTSJumps">
+     <property name="geometry">
+      <rect>
+       <x>630</x>
+       <y>130</y>
+       <width>101</width>
+       <height>111</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>PTS Jumps</string>
+     </property>
+     <widget class="QRadioButton" name="rbPTSDefault">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>30</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Ignore jumps</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbPTSFix">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>70</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Fix jumps</string>
+      </property>
+     </widget>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabInput2">
     <attribute name="title">
@@ -566,7 +618,7 @@ QGroupBox::title {
        <rect>
         <x>10</x>
         <y>20</y>
-        <width>631</width>
+        <width>451</width>
         <height>232</height>
        </rect>
       </property>
@@ -595,7 +647,7 @@ QGroupBox::title {
        <item>
         <widget class="QCheckBox" name="cbMiscWTV">
          <property name="text">
-          <string>Work around a bug in Windows 7's built in software when converted from *.wtv to *.dvr-ms</string>
+          <string>Work around a bug in Windows 7 converting from *.wtv to *.dvr-ms</string>
          </property>
         </widget>
        </item>
@@ -686,7 +738,7 @@ QGroupBox::title {
       <rect>
        <x>10</x>
        <y>0</y>
-       <width>721</width>
+       <width>161</width>
        <height>131</height>
       </rect>
      </property>
@@ -699,7 +751,7 @@ QGroupBox::title {
         <x>10</x>
         <y>20</y>
         <width>631</width>
-        <height>101</height>
+        <height>111</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -739,6 +791,225 @@ QGroupBox::title {
         </widget>
        </item>
       </layout>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbSubtitle">
+     <property name="geometry">
+      <rect>
+       <x>179</x>
+       <y>-1</y>
+       <width>551</width>
+       <height>131</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Subtitles</string>
+     </property>
+     <widget class="QWidget" name="horizontalLayoutWidget_11">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>261</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_17">
+       <item>
+        <widget class="QCheckBox" name="cbDVBLang">
+         <property name="text">
+          <string>Select DVB language</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leDVBLang"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="horizontalLayoutWidget_12">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>100</y>
+        <width>531</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_18">
+       <item>
+        <widget class="QCheckBox" name="cbOCRName">
+         <property name="text">
+          <string>Select OCR file name</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leOCRName"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="buttonOCRName">
+         <property name="text">
+          <string>Browse</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="gbQuant">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>211</width>
+        <height>61</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Quantization</string>
+      </property>
+      <widget class="QRadioButton" name="rbQuantNone">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>71</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>None</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbQuantDefault">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>40</y>
+         <width>81</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>CCExtractor</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbQuantLess">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>20</y>
+         <width>101</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Fast (less colors)</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="horizontalLayoutWidget_13">
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>20</y>
+        <width>261</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_19">
+       <item>
+        <widget class="QCheckBox" name="cbMKVLang">
+         <property name="text">
+          <string>Select MKV language</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leMKVLang"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="gbOEM">
+      <property name="geometry">
+       <rect>
+        <x>230</x>
+        <y>40</y>
+        <width>141</width>
+        <height>61</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>OEM Mode</string>
+      </property>
+      <widget class="QRadioButton" name="rbOEMDefault">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>82</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Tesseract</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbOEMLSTM">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>40</y>
+         <width>82</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>LSTM</string>
+       </property>
+      </widget>
+      <widget class="QRadioButton" name="rbOEMBoth">
+       <property name="geometry">
+        <rect>
+         <x>90</x>
+         <y>20</y>
+         <width>101</width>
+         <height>31</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Both</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QCheckBox" name="cbNoSpupngocr">
+      <property name="geometry">
+       <rect>
+        <x>390</x>
+        <y>60</y>
+        <width>151</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label">
+      <property name="geometry">
+       <rect>
+        <x>416</x>
+        <y>49</y>
+        <width>121</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>When processing DVB, don't use OCR for comments in the XML file.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
      </widget>
     </widget>
    </widget>
@@ -1234,6 +1505,22 @@ QGroupBox::title {
       </property>
      </widget>
     </widget>
+    <widget class="QCheckBox" name="cbTickerTape">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>160</x>
+       <y>280</y>
+       <width>281</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Search for burned-in text at the bottom of the screen</string>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabDebug">
     <attribute name="title">
@@ -1245,21 +1532,21 @@ QGroupBox::title {
        <x>10</x>
        <y>10</y>
        <width>721</width>
-       <height>402</height>
+       <height>372</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="cbDebugFullBin">
+        <property name="text">
+         <string>FullBin (Disable removal of trailing padding blocks when exporting to bin)</string>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="0">
        <widget class="QCheckBox" name="cbDebugNoSync">
         <property name="text">
          <string>NoSync (Disable the syncing code. Only useful for debugging purposes.)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="cbDebugFullBin">
-        <property name="text">
-         <string>FullBin (Disable the removal of trailing padding blocks when exporting to bin format)</string>
         </property>
        </widget>
       </item>
@@ -1273,7 +1560,7 @@ QGroupBox::title {
       <item row="8" column="0">
        <widget class="QCheckBox" name="cbDebugParse">
         <property name="text">
-         <string>Parse (Print debug info about the parsed container file. Only for TS/ASF files at the moment.)</string>
+         <string>Parse (Print debug info about the parsed container file for TS/ASF files.)</string>
         </property>
        </widget>
       </item>
@@ -1291,13 +1578,6 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="11" column="0">
-       <widget class="QCheckBox" name="cbDebugInvestigate">
-        <property name="text">
-         <string>Investigate packets (If no CC packets are detected using the PMT, try to find data in all packets by scanning)</string>
-        </property>
-       </widget>
-      </item>
       <item row="10" column="0">
        <widget class="QCheckBox" name="cbDebugPMT">
         <property name="text">
@@ -1305,10 +1585,24 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
+      <item row="11" column="0">
+       <widget class="QCheckBox" name="cbDebugInvestigate">
+        <property name="text">
+         <string>Investigate packets (Find data in all packets by scanning w/o PMT)</string>
+        </property>
+       </widget>
+      </item>
       <item row="9" column="0">
        <widget class="QCheckBox" name="cbDebugPAT">
         <property name="text">
          <string>PAT (Print Program Association Table dump)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="cbDebug708">
+        <property name="text">
+         <string>708 (Print debug information from the EIA-708 (DTV) decoder)</string>
         </property>
        </widget>
       </item>
@@ -1333,14 +1627,7 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="cbDebug708">
-        <property name="text">
-         <string>708 (Print debug information from the EIA-708 (DTV) decoder)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0">
+      <item row="15" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_13">
         <item>
          <widget class="QCheckBox" name="cbDebugESFile">
@@ -1375,6 +1662,41 @@ QGroupBox::title {
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="cbDebugDVBSUB">
+        <property name="text">
+         <string>Write DVB subtitle debug traces to console.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0">
+       <widget class="QCheckBox" name="cbPESHeader">
+        <property name="text">
+         <string>Dump the PES header to stdout (debug packet headers)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="cbDeblev">
+        <property name="text">
+         <string>Show calculated distance between strings for typo correction</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="cbAnvid">
+        <property name="text">
+         <string>Analyze the video stream for video information</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="cbSharingDebug">
+        <property name="text">
+         <string>Print extracted CC sharing service messages</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </widget>
@@ -1388,7 +1710,7 @@ QGroupBox::title {
        <x>10</x>
        <y>0</y>
        <width>721</width>
-       <height>121</height>
+       <height>131</height>
       </rect>
      </property>
      <property name="title">
@@ -1489,6 +1811,34 @@ QGroupBox::title {
          </property>
         </widget>
        </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_20">
+         <item>
+          <widget class="QLineEdit" name="leOutputFont">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnOutputFont">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="cbOutputFont">
+         <property name="text">
+          <string>Font filename</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -1496,7 +1846,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>130</y>
+       <y>140</y>
        <width>121</width>
        <height>81</height>
       </rect>
@@ -1551,7 +1901,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>140</x>
-       <y>130</y>
+       <y>140</y>
        <width>191</width>
        <height>80</height>
       </rect>
@@ -1593,7 +1943,7 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>340</x>
-       <y>130</y>
+       <y>140</y>
        <width>391</width>
        <height>81</height>
       </rect>
@@ -1655,9 +2005,9 @@ QGroupBox::title {
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>220</y>
-       <width>361</width>
-       <height>171</height>
+       <y>230</y>
+       <width>381</width>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
@@ -1721,10 +2071,10 @@ QGroupBox::title {
       </property>
       <property name="geometry">
        <rect>
-        <x>200</x>
+        <x>150</x>
         <y>140</y>
         <width>81</width>
-        <height>25</height>
+        <height>20</height>
        </rect>
       </property>
      </widget>
@@ -1745,10 +2095,10 @@ QGroupBox::title {
     <widget class="QGroupBox" name="gbOutputTranscript">
      <property name="geometry">
       <rect>
-       <x>380</x>
-       <y>220</y>
-       <width>351</width>
-       <height>171</height>
+       <x>400</x>
+       <y>230</y>
+       <width>331</width>
+       <height>161</height>
       </rect>
      </property>
      <property name="title">
@@ -1786,9 +2136,9 @@ QGroupBox::title {
      <widget class="QLineEdit" name="leOutputTranscriptUnixRef">
       <property name="geometry">
        <rect>
-        <x>190</x>
+        <x>150</x>
         <y>20</y>
-        <width>151</width>
+        <width>161</width>
         <height>25</height>
        </rect>
       </property>
@@ -1846,7 +2196,7 @@ QGroupBox::title {
       <rect>
        <x>10</x>
        <y>200</y>
-       <width>721</width>
+       <width>491</width>
        <height>191</height>
       </rect>
      </property>
@@ -1858,7 +2208,7 @@ QGroupBox::title {
        <rect>
         <x>10</x>
         <y>20</y>
-        <width>271</width>
+        <width>265</width>
         <height>191</height>
        </rect>
       </property>
@@ -1928,13 +2278,60 @@ QGroupBox::title {
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="verticalLayoutWidget_9">
+      <property name="geometry">
+       <rect>
+        <x>279</x>
+        <y>19</y>
+        <width>216</width>
+        <height>171</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_9">
+       <item>
+        <widget class="QCheckBox" name="cbChapters">
+         <property name="text">
+          <string>Produce a chapter file for MP4</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbAppend">
+         <property name="text">
+          <string>Append to output files</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbWebvttCSS">
+         <property name="text">
+          <string>Create separate CSS file for WebVTT</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbSegmentKey">
+         <property name="text">
+          <string>Segment output only after I frames</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbSplitSentence">
+         <property name="text">
+          <string>Split output text by complete sentences</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
     <widget class="QGroupBox" name="gbOutputTranscript2">
      <property name="geometry">
       <rect>
        <x>10</x>
        <y>0</y>
-       <width>721</width>
+       <width>391</width>
        <height>191</height>
       </rect>
      </property>
@@ -1963,9 +2360,9 @@ QGroupBox::title {
       </property>
       <property name="geometry">
        <rect>
-        <x>150</x>
+        <x>170</x>
         <y>10</y>
-        <width>281</width>
+        <width>221</width>
         <height>181</height>
        </rect>
       </property>
@@ -1980,7 +2377,7 @@ QGroupBox::title {
         <rect>
          <x>10</x>
          <y>20</y>
-         <width>271</width>
+         <width>221</width>
          <height>157</height>
         </rect>
        </property>
@@ -2042,6 +2439,299 @@ QGroupBox::title {
         </item>
        </layout>
       </widget>
+     </widget>
+     <widget class="QCheckBox" name="cbOutputXDS">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>151</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Save XDS info to transcript</string>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbLevenshtein">
+     <property name="geometry">
+      <rect>
+       <x>409</x>
+       <y>-1</y>
+       <width>321</width>
+       <height>101</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Typo Correction</string>
+     </property>
+     <widget class="QCheckBox" name="cbNoLeven">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>171</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>No typo correction</string>
+      </property>
+     </widget>
+     <widget class="QWidget" name="formLayoutWidget_3">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>305</width>
+        <height>51</height>
+       </rect>
+      </property>
+      <layout class="QFormLayout" name="formLayout_6">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="cbMinNum">
+         <property name="text">
+          <string>Minimum allowed difference w/o correction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="cbMaxPct">
+         <property name="text">
+          <string>Maximum difference percentage w/ correction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="leMinNum">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="leMaxPct">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbTranslate">
+     <property name="geometry">
+      <rect>
+       <x>410</x>
+       <y>110</y>
+       <width>321</width>
+       <height>80</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Translation</string>
+     </property>
+     <widget class="QCheckBox" name="cbTranslate">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>91</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string> Translate to:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leTranslate">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>100</x>
+        <y>20</y>
+        <width>211</width>
+        <height>20</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>50</y>
+        <width>81</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Authentication:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leTranslateAuth">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>90</x>
+        <y>50</y>
+        <width>221</width>
+        <height>20</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbSharing">
+     <property name="geometry">
+      <rect>
+       <x>510</x>
+       <y>200</y>
+       <width>221</width>
+       <height>91</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>Sharing</string>
+     </property>
+     <widget class="QCheckBox" name="cbEnableSharing">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>269</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Enable sharing</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="lblEnableSharing">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>71</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Sharing URL:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leEnableSharing">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>201</width>
+        <height>20</height>
+       </rect>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QGroupBox" name="gbXMLTV">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>510</x>
+       <y>300</y>
+       <width>221</width>
+       <height>91</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string>XMLTV</string>
+     </property>
+     <widget class="QRadioButton" name="rbXMLTVFull">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Full file</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbXMLTVLive">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Live file</string>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="rbXMLTVBoth">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>60</y>
+        <width>82</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Both files</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cbXMLTVCurrent">
+      <property name="geometry">
+       <rect>
+        <x>80</x>
+        <y>20</y>
+        <width>141</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Only print current events</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="cbXMLTVInterval">
+      <property name="geometry">
+       <rect>
+        <x>80</x>
+        <y>40</y>
+        <width>121</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Output at interval:</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="leXMLTVInterval">
+      <property name="geometry">
+       <rect>
+        <x>80</x>
+        <y>60</y>
+        <width>131</width>
+        <height>20</height>
+       </rect>
+      </property>
      </widget>
     </widget>
    </widget>


### PR DESCRIPTION
Added a variety of options that were missing from the previous build:

Main window:
- Added TCP (-tcp, -tcppassword, -tcpdesc)

Options window:
- Enabled "Decoder" page
- Added SubStation Alpha, WebVTT, report to the output types (-out=ass/ssa,webvtt,report)
- Added "Codec" options to the "Input (2)" page (-codec/nocodec dvbsub/teletext)
- Added -wtvmpeg2 and --noscte20 to the "Input (2)" page
- Added -dumpdef to the "Debug" page
- Added -unicode to the possible encodings on the "Output" page
- Added a "Output (2)" page with -bom/-nobom, --nohtmlescape, -xmltv, -sem, -outinterval, and -customtxt options.
- Added -koc and -ff to the "Decoder" page.
- Added functionality to the -svc textbox on the "Decoder" page.

Some changes in the .ui files were automatically caused by Qt Creator.